### PR TITLE
[SHTL-234] En el saludo del huésped (¡Hello Mateo!) Quitar el primer signo ay que no existe en inglés.

### DIFF
--- a/apps/guest/src/home/pages/guest-requests/guest-requests.component.html
+++ b/apps/guest/src/home/pages/guest-requests/guest-requests.component.html
@@ -1,7 +1,7 @@
 <contler-marco padding="0">
   <div marcoBody class="main-container">
     <p class="request__label request__user request__question" contlerColorHotel>
-      ¡Hello {{ ($guest | async)?.name }}!
+      Hello {{ ($guest | async)?.name }}!
     </p>
     <p class="request__label request__space request__question" contlerColorHotel>Where do you need us?</p>
 


### PR DESCRIPTION
[SHTL-234](https://pappcorn.atlassian.net/browse/SHTL-234)

* Quitar signo de admiración

# Evidencia: 

![image](https://user-images.githubusercontent.com/20249366/96934060-30fd9e00-1487-11eb-941c-362db75b25c6.png)
